### PR TITLE
ReplaceTexture update, shuffle icons added

### DIFF
--- a/mod.cpp
+++ b/mod.cpp
@@ -1,36 +1,67 @@
 #include "pch.h"
 #include "IniFile.hpp"
-// or #include "stdafx.h" for previous Visual Studio versions
 
-#define ReplacePVM(a, b) helperFunctions.ReplaceFile("system\\" a ".PVM", "system\\" b ".PVM")
+using namespace std;
 
 extern "C"
 {
 	__declspec(dllexport) void __cdecl Init(const char* path, const HelperFunctions& helperFunctions)
 	{
-		// Executed at startup, contains helperFunctions and the path to your mod (useful for getting the config file.)
-		// This is where we override functions, replace static data, etc.
-		const IniFile* config = new IniFile(std::string(path) + "\\config.ini");
+		// texture names in obj_regular to replace
+		const char* namesToReplace[7] = {
+			"item_1up",
+			"1uptails",
+			"1upknuck",
+			"1upamy",
+			"1upbig",
+			"1up102",
+			"1upmetal"
+		};
+
+		// respective indices for above list
+		uint32_t gbix[7] = {
+			4031,
+			4004,
+			4000,
+			4001,
+			4002,
+			4003,
+			710226
+		};
+
+		string moddir = path;
+
+		// Read config
+		const IniFile* config = new IniFile(moddir + "\\config.ini");
 
 		bool borders = config->getBool("", "Borders", true);
-		bool altSuper = config->getBool("", "AltSuper", false);
-		if (!borders) {
-			ReplacePVM("OBJ_REGULAR", "OBJ_REGULAR_NOBORDER");
+		string style = config->getString("", "Style", "Default");
 
-			if (altSuper) {
-				ReplacePVM("SUPERSONIC_EXTRA", "SUPERSONIC_EXTRA_ALTERNATE_NOBORDER");
-			}
-			else {
-				ReplacePVM("SUPERSONIC_EXTRA", "SUPERSONIC_EXTRA_NOBORDER");
-			}
+		bool shuffle = (style == "Shuffle");
+		bool altSuper = shuffle || (style == "Shuffle Super Sonic");
+
+		// Replaced textures use suffixes for alternates, e.g. item_1up_SHUFFLE_NOBORDERS.png
+		string suffix = shuffle ? "_SHUFFLE" : "";
+		if (!borders) suffix += "_NOBORDER";
+
+		const char* filepath = "";
+		for (int i = 0; i < 7; i++)
+		{
+			// e.g.   <mod folder> \replacetex\1UP_CUSTOM\         item_1up        _SHUFFLE   .png
+			filepath = (moddir + "\\replacetex\\1UP_CUSTOM\\" + namesToReplace[i] + suffix + ".png").c_str();
+			
+			helperFunctions.ReplaceTexture("OBJ_REGULAR", namesToReplace[i], filepath, gbix[i], 128, 128);
 		}
-		else {
-			ReplacePVM("OBJ_REGULAR", "OBJ_REGULAR_HD"); // Redundant with HD GUI but ensures compatibility
-			if (altSuper) {
-				ReplacePVM("SUPERSONIC_EXTRA", "SUPERSONIC_EXTRA_ALTERNATE");
-			}
-		}
+
+		// Super Sonic has an additional option
+		suffix = altSuper ? "_SHUFFLE" : "";
+		if (!borders) suffix += "_NOBORDER";
+		
+		// e.g.   <mod folder> \replacetex\1UP_CUSTOM\  1upsuper   _SHUFFLE   .png
+		filepath = (moddir + "\\replacetex\\1UP_CUSTOM\\1upsuper" + suffix + ".png").c_str();
+		helperFunctions.ReplaceTexture("SUPERSONIC_EXTRA", "1upsuper", filepath, 6544685, 128, 128);
+		
 	}
 
-	__declspec(dllexport) ModInfo SADXModInfo = { ModLoaderVer }; // This is needed for the Mod Loader to recognize the DLL.
+	__declspec(dllexport) ModInfo SADXModInfo = { ModLoaderVer };
 }


### PR DESCRIPTION
4.0 update: replacetexture to add compatibility, reduce file size. shuffle icons added as an option. super sonic compatibility functional with workaround